### PR TITLE
fix compilation with latest VitaSDK

### DIFF
--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -275,7 +275,7 @@ else ifeq ($(platform), vita)
    LIBS += -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub\
            -lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceAudio_stub -lSceFiber_stub\
            -lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
-           -lSceMotion_stub -lSceAppMgr_stub -lpng -lm -lc
+           -lSceMotion_stub -lSceAppMgr_stub -lSceDriverUser_stub -lpng -lm -lc
 
    PLATOBJS += $(DEPS_DIR)/libvita2d/shader/clear_v_gxp.o \
       $(DEPS_DIR)/libvita2d/shader/clear_f_gxp.o \

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -118,7 +118,7 @@ CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions
 VITA_LIBS := -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub \
 	-lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceAudio_stub \
 	-lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
-	-lSceFiber_stub -lSceMotion_stub -lSceAppMgr_stub -lpthread -lpng -lz
+	-lSceFiber_stub -lSceMotion_stub -lSceAppMgr_stub -lSceDriverUser_stub -lpthread -lpng -lz
 
 LIBS	:= $(WHOLE_START) -lretro_vita $(WHOLE_END) $(VITA_LIBS) -lm -lc
 

--- a/Makefile.vita.salamander
+++ b/Makefile.vita.salamander
@@ -24,7 +24,7 @@ LDFLAGS =
 LIBS = -lSceDisplay_stub -lSceGxm_stub -lSceNet_stub -lSceNetCtl_stub\
      -lSceSysmodule_stub -lSceCtrl_stub -lSceHid_stub -lSceAudio_stub -lSceFiber_stub\
      -lScePower_stub -lSceRtc_stub -lSceCommonDialog_stub -lScePgf_stub \
-     -lSceMotion_stub -lSceAppMgr_stub -lfreetype -lpng -lm -lc
+     -lSceMotion_stub -lSceAppMgr_stub -lSceDriverUser_stub -lfreetype -lpng -lm -lc
 
 ifeq ($(HAVE_FILE_LOGGER), 1)
 CFLAGS		+= -DHAVE_FILE_LOGGER


### PR DESCRIPTION
Some imports have been moved from libSceAppMgr_stub to libSceDriverUser_stub.

By including -lSceDriverUser_stub the whole thing becomes compilable again on the latest VitaSDK, and even on older VitaSDK builds including this stub shouldn't cause any harm.